### PR TITLE
include version.json download url in action output

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -36,4 +36,6 @@ jobs:
           echo "${{steps.test-action.outputs.version-previous-release}}"
           echo "${{steps.test-action.outputs.version-previous-snapshot}}"
           echo "${{steps.test-action.outputs.version-current-release}}"
+          echo "${{steps.test-action.outputs.version-current-release-url}}"
           echo "${{steps.test-action.outputs.version-current-snapshot}}"
+          echo "${{steps.test-action.outputs.version-current-snapshot-url}}"

--- a/README.md
+++ b/README.md
@@ -30,18 +30,22 @@ A big advantage of this action compared to other actions is that no additional f
     echo "Previous release version: ${{steps.version-change.outputs.version-previous-release}}"
     echo "Previous snapshot version: ${{steps.version-change.outputs.version-previous-snapshot}}"
     echo "Current release version: ${{steps.version-change.outputs.version-current-release}}"
+    echo "Release version.json URL: ${{steps.version-change.outputs.version-current-release-url}}"
     echo "Current snapshot version: ${{steps.version-change.outputs.version-current-snapshot}}"
+    echo "Snapshot version.json URL: ${{steps.version-change.outputs.version-current-snapshot-url}}"
 ```
 
-|          Parameter          |  Datatype | Description                                           |
-|:---------------------------:|:---------:|-------------------------------------------------------|
-|      `version-changed`      | `boolean` | Whether the release or snapshot version has changed   |
-|  `version-release-changed`  | `boolean` | Whether the release version has changed               |
-| `version-snapshot-changed`  | `boolean` | Whether the snapshot version has changed              |
-| `version-current-release`   | `string`  | The current Minecraft release version fetched         |
-| `version-current-snapshot`  | `string`  | The current Minecraft snapshot version fetched        |
-| `version-previous-release`  | `string`  | The previous Minecraft release version from artifact  |
-| `version-previous-snapshot` | `string`  | The previous Minecraft snapshot version from artifact |
+|          Parameter              |  Datatype | Description                                           |
+|:-------------------------------:|:---------:|-------------------------------------------------------|
+|      `version-changed`          | `boolean` | Whether the release or snapshot version has changed   |
+|  `version-release-changed`      | `boolean` | Whether the release version has changed               |
+| `version-snapshot-changed`      | `boolean` | Whether the snapshot version has changed              |
+| `version-current-release`       | `string`  | The current Minecraft release version fetched         |
+| `version-current-release-url`   | `string`  | The download url of the release version.json file.    |
+| `version-current-snapshot`      | `string`  | The current Minecraft snapshot version fetched        |
+| `version-current-snapshot-url`  | `string`  | The download url of the snapshot version.json file.   |
+| `version-previous-release`      | `string`  | The previous Minecraft release version from artifact  |
+| `version-previous-snapshot`     | `string`  | The previous Minecraft snapshot version from artifact |
 
 ## Usage
 ```yml
@@ -75,7 +79,9 @@ jobs:
           echo "Previous release version: ${{steps.version-change.outputs.version-previous-release}}"
           echo "Previous snapshot version: ${{steps.version-change.outputs.version-previous-snapshot}}"
           echo "Current release version: ${{steps.version-change.outputs.version-current-release}}"
+          echo "Release version.json URL: ${{steps.version-change.outputs.version-current-release-url}}"
           echo "Current snapshot version: ${{steps.version-change.outputs.version-current-snapshot}}"
+          echo "Snapshot version.json URL: ${{steps.version-change.outputs.version-current-snapshot-url}}"
 
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,14 @@ outputs:
   version-current-release:
     description: 'The current Minecraft release version fetched.'
 
+  version-current-release-url:
+    description: 'The download url of the release version.json file.'
+
   version-current-snapshot:
     description: 'The current Minecraft snapshot version fetched.'
+
+  version-current-snapshot-url:
+    description: 'The download url of the snapshot version.json file.'
 
   version-previous-release:
     description: 'The previous Minecraft release version from artifact.'

--- a/src/fetch_manifest_data.ts
+++ b/src/fetch_manifest_data.ts
@@ -1,10 +1,10 @@
 import { Latest } from './interface/latest.ts';
 import { ManifestData } from './interface/manifest_data.ts';
 
-export function fetchManifestData(url : string) : Promise<Latest> {
+export function fetchManifestData(url : string) : Promise<ManifestData> {
   return fetch(url).then(async (response) => {
     try {
-      return (await (await response.json() as Promise<ManifestData>)).latest;
+      return (await (await response.json() as Promise<ManifestData>));
     } catch (error) {
       throw new Error(error)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ const repositoryName = actionsGithub.context.repo.repo;
 (async () => {
   actionsCore.startGroup(`Fetching current manifest version from "${inputManifestURL}" ...`)
   const currentManifest = await fetchManifestData(inputManifestURL);
-  const releaseVersion = currentManifest.versions.find(v => v.id == currentManifest.latest.release);
-  const snapshotVersion = currentManifest.versions.find(v => v.id == currentManifest.latest.snapshot);
+  const releaseVersion = currentManifest.versions.find(version => version.id == currentManifest.latest.release);
+  const snapshotVersion = currentManifest.versions.find(version => version.id == currentManifest.latest.snapshot);
   actionsCore.info('Found latest version:');
   actionsCore.info(`- Release: ${currentManifest.latest.release} (url: ${releaseVersion?.url})`);
   actionsCore.info(`- Snapshot: ${currentManifest.latest.snapshot} (url: ${snapshotVersion?.url})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,17 @@ const repositoryName = actionsGithub.context.repo.repo;
 (async () => {
   actionsCore.startGroup(`Fetching current manifest version from "${inputManifestURL}" ...`)
   const currentManifest = await fetchManifestData(inputManifestURL);
+  const releaseVersion = currentManifest.versions.find(v => v.id == currentManifest.latest.release);
+  const snapshotVersion = currentManifest.versions.find(v => v.id == currentManifest.latest.snapshot);
   actionsCore.info('Found latest version:');
-  actionsCore.info(`- Release: ${currentManifest.release}`);
-  actionsCore.info(`- Snapshot: ${currentManifest.snapshot}`);
+  actionsCore.info(`- Release: ${currentManifest.latest.release} (url: ${releaseVersion?.url})`);
+  actionsCore.info(`- Snapshot: ${currentManifest.latest.snapshot} (url: ${snapshotVersion?.url})`);
   actionsCore.endGroup();
 
-  actionsCore.setOutput('version-current-release', currentManifest.release);
-  actionsCore.setOutput('version-current-snapshot', currentManifest.snapshot);
+  actionsCore.setOutput('version-current-release', currentManifest.latest.release);
+  actionsCore.setOutput('version-current-release-url', releaseVersion?.url);
+  actionsCore.setOutput('version-current-snapshot', currentManifest.latest.snapshot);
+  actionsCore.setOutput('version-current-snapshot-url', snapshotVersion?.url);
   
   actionsCore.startGroup('Getting artifacts ...');
   actionsCore.info('Searching existing artifacts ...');
@@ -72,8 +76,8 @@ const repositoryName = actionsGithub.context.repo.repo;
     const previousManifest = await readManifestFile('./artifacts/manifest.json');
     actionsCore.endGroup();
 
-    const versionRelaseChanged = previousManifest?.release !== currentManifest.release;
-    const versionSnapshotChanged = previousManifest?.snapshot !== currentManifest.snapshot;
+    const versionRelaseChanged = previousManifest?.release !== currentManifest.latest.release;
+    const versionSnapshotChanged = previousManifest?.snapshot !== currentManifest.latest.snapshot;
     const versionChanged = versionRelaseChanged || versionSnapshotChanged;
       
     actionsCore.setOutput('version-changed', versionChanged);
@@ -84,7 +88,7 @@ const repositoryName = actionsGithub.context.repo.repo;
   }
   
   actionsCore.startGroup('Writing new current manifest ...');
-  await writeManifestFile('./artifacts/manifest.json', currentManifest);
+  await writeManifestFile('./artifacts/manifest.json', currentManifest.latest);
   actionsCore.endGroup();
   
   actionsCore.startGroup('Uploading new current artifact ...');
@@ -95,4 +99,3 @@ const repositoryName = actionsGithub.context.repo.repo;
   )
   actionsCore.endGroup();
 })()
-


### PR DESCRIPTION
This pr adds the ability to get the download URL for the version.json file directly from the actions output. The URL is available for both, the current release and the current snapshot.

- `outputs.version-current-release-url`
- `outputs.version-current-snapshot-url`

Because In my case I only need the current versions URL, it is not available for the previous versions. However it is as easy to include the URL (and other version data fields btw) for the previous version.

Also: view updated README file:
https://github.com/Kesuaheli/minecraft-manifest/blob/6737ee28048fc66173370a3c79b303452c47f495/README.md